### PR TITLE
Import Buffer explicitly so it works in React Native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,12 +111,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@types/node": {
-      "version": "10.12.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
-      "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==",
-      "dev": true
-    },
     "ajv": {
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
@@ -192,6 +186,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -228,6 +227,15 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
+    },
+    "buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -542,6 +550,11 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "imurmurhash": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "base64url",
-  "version": "3.0.1",
+  "name": "uport-base64url",
+  "version": "3.0.2-alpha.0",
   "description": "For encoding to/from base64urls",
   "main": "index.js",
   "types": "./dist/base64url.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "node": ">=6.0.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0",
     "tap": "^12.1.0"
+  },
+  "dependencies": {
+    "buffer": "^5.2.1"
   }
 }

--- a/src/base64url.ts
+++ b/src/base64url.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import padString from "./pad-string";
 
 function encode(input: string | Buffer, encoding: string = "utf8"): string {

--- a/src/pad-string.ts
+++ b/src/pad-string.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer'
+
 export default function padString(input: string): string {
     let segmentLength = 4;
     let stringLength = input.length;


### PR DESCRIPTION
`base64url` was originally written for a node environment and thus assumes that `Buffer` is globally available.  This causes React Native projects (which do not provide `Buffer`) using it as a dependency to break.  Explicitly providing `Buffer` using the node module `[buffer](https://www.npmjs.com/package/buffer)` fixes this issue.

Note that the dev dependency on `@types/node` which was used to provide type definitions for `Buffer` was removed since they now come from the `buffer` module itself.